### PR TITLE
Various optimisations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
 
 COPY run-ghost.sh $GHOST_INSTALL
 
-# Here we could add themes within the image
+# Here we could add custom themes within the Docker image
 
 # Keeping Original GhostContent to be copied into the mounted volume (if empty)
 RUN cp -r "$GHOST_CONTENT" "$GHOST_INSTALL/content.bck" ;

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,37 +4,37 @@
 FROM node:6-alpine as ghost-builder
 
 RUN \
-    apk update && apk upgrade                       	&& \
-    apk add --no-cache wget unzip ca-certificates   	&& \
-    echo												&& \
-    echo "--- Install ghost-cli --- "; echo         	&& \
-    npm install --loglevel=error -g ghost-cli			;
+    apk update && apk upgrade                           && \
+    echo                                                && \
+    echo "--- Install ghost-cli --- "; echo             && \
+    npm install --loglevel=error -g ghost-cli           ;
 
-ENV GHOST_VERSION="1.17.1"							    \
-	GHOST_INSTALL="/var/lib/ghost"					    \
-	GHOST_CONTENT="/var/lib/ghost/content"			    \
-	GHOST_THEMES="/var/lib/ghost/content/themes"	    \
-	GHOST_USER="node"
+ENV GHOST_VERSION="1.17.1"                              \
+    GHOST_INSTALL="/var/lib/ghost"                      \
+    GHOST_CONTENT="/var/lib/ghost/content"              \
+    GHOST_USER="node"
 
 # Set default directory
 WORKDIR $GHOST_INSTALL
 
 # Run SQLite as database
 RUN \
-	ghost install "$GHOST_VERSION" \
-		--db sqlite3 --no-prompt \
-		--no-stack --no-setup \
-		--dir "$GHOST_INSTALL"							&& \
-	ghost config --ip 0.0.0.0 \
-		--port 2368 --no-prompt --db sqlite3 \
-		--url http://localhost:2368 \
-		--dbpath "$GHOST_CONTENT/data/ghost.db"			&& \
-	ghost config paths.contentPath "$GHOST_CONTENT"		;
+    ghost install "$GHOST_VERSION" \
+        --db sqlite3 --no-prompt \
+        --no-stack --no-setup \
+        --dir "$GHOST_INSTALL"                          && \
+    ghost config --ip 0.0.0.0 \
+        --port 2368 --no-prompt --db sqlite3 \
+        --url http://localhost:2368 \
+        --dbpath "$GHOST_CONTENT/data/ghost.db"         && \
+    ghost config paths.contentPath "$GHOST_CONTENT"     ;
 
 COPY run-ghost.sh $GHOST_INSTALL
 
+# Here we could add themes within the image
+
 # Keeping Original GhostContent to be copied into the mounted volume (if empty)
-RUN cp -r "$GHOST_CONTENT" "$GHOST_INSTALL/content.bck"	;
+RUN cp -r "$GHOST_CONTENT" "$GHOST_INSTALL/content.bck" ;
 
 
 ### ### ### ### ### ### ### ### ###
@@ -44,14 +44,14 @@ RUN cp -r "$GHOST_CONTENT" "$GHOST_INSTALL/content.bck"	;
 FROM node:6-alpine
 LABEL maintainer="Marco Mornati <marco@mornati.net>"
 
-RUN apk update && apk upgrade		                && \
-	apk add --no-cache tini			                && \
-	rm -rf /var/cache/apk/*			                ;
+RUN apk update && apk upgrade                           && \
+    apk add --no-cache tini                             && \
+    rm -rf /var/cache/apk/*                             ;
 
-ENV GHOST_VERSION="1.17.1"							\
-	GHOST_INSTALL="/var/lib/ghost"					\
-	GHOST_CONTENT="/var/lib/ghost/content" 			\
-	GHOST_USER="node"
+ENV GHOST_VERSION="1.17.1"                              \
+    GHOST_INSTALL="/var/lib/ghost"                      \
+    GHOST_CONTENT="/var/lib/ghost/content"              \
+    GHOST_USER="node"
 
 # Install Ghost
 COPY --from=ghost-builder --chown=node $GHOST_INSTALL $GHOST_INSTALL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,57 @@
-#
+### ### ### ### ### ### ### ### ###
 # Builder layer
-#
+
 FROM node:6-alpine as ghost-builder
-RUN npm install --loglevel=error -g ghost-cli
 
-ENV GHOST_VERSION 1.17.1
-ENV GHOST_INSTALL /var/lib/ghost
-ENV GHOST_CONTENT /var/lib/ghost/content
-ENV GHOST_USER node
+RUN \
+    apk update && apk upgrade                       	&& \
+    apk add --no-cache wget unzip ca-certificates   	&& \
+    echo												&& \
+    echo "--- Install ghost-cli --- "; echo         	&& \
+    npm install --loglevel=error -g ghost-cli			;
 
+ENV GHOST_VERSION="1.17.1"							    \
+	GHOST_INSTALL="/var/lib/ghost"					    \
+	GHOST_CONTENT="/var/lib/ghost/content"			    \
+	GHOST_THEMES="/var/lib/ghost/content/themes"	    \
+	GHOST_USER="node"
+
+# Set default directory
 WORKDIR $GHOST_INSTALL
 
 # Run SQLite as database
 RUN \
-	ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
-	ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
-	ghost config paths.contentPath "$GHOST_CONTENT";
+	ghost install "$GHOST_VERSION" \
+		--db sqlite3 --no-prompt \
+		--no-stack --no-setup \
+		--dir "$GHOST_INSTALL"							&& \
+	ghost config --ip 0.0.0.0 \
+		--port 2368 --no-prompt --db sqlite3 \
+		--url http://localhost:2368 \
+		--dbpath "$GHOST_CONTENT/data/ghost.db"			&& \
+	ghost config paths.contentPath "$GHOST_CONTENT"		;
 
 COPY run-ghost.sh $GHOST_INSTALL
 
-#
+# Keeping Original GhostContent to be copied into the mounted volume (if empty)
+RUN cp -r "$GHOST_CONTENT" "$GHOST_INSTALL/content.bck"	;
+
+
+### ### ### ### ### ### ### ### ###
 # Final image
-#
+# No tzdata as it's not working on alpine3.4 (from node6)
+
 FROM node:6-alpine
 LABEL maintainer="Marco Mornati <marco@mornati.net>"
 
-ENV GHOST_VERSION 1.17.1
-ENV GHOST_INSTALL /var/lib/ghost
-ENV GHOST_CONTENT /var/lib/ghost/content
-ENV GHOST_USER node
+RUN apk update && apk upgrade		                && \
+	apk add --no-cache tini			                && \
+	rm -rf /var/cache/apk/*			                ;
+
+ENV GHOST_VERSION="1.17.1"							\
+	GHOST_INSTALL="/var/lib/ghost"					\
+	GHOST_CONTENT="/var/lib/ghost/content" 			\
+	GHOST_USER="node"
 
 # Install Ghost
 COPY --from=ghost-builder --chown=node $GHOST_INSTALL $GHOST_INSTALL
@@ -36,9 +59,6 @@ COPY --from=ghost-builder --chown=node $GHOST_INSTALL $GHOST_INSTALL
 USER $GHOST_USER
 ENV HOME $GHOST_INSTALL
 ENV PATH="${GHOST_INSTALL}/current/node_modules/knex-migrator/bin:${PATH}"
-
-# Keeping Original GhostContent to be copied into the mounted volume (if empty)
-RUN cp -r "$GHOST_CONTENT" "$GHOST_INSTALL/content.bck";
 
 # Define working directory
 WORKDIR $GHOST_INSTALL
@@ -56,4 +76,4 @@ HEALTHCHECK CMD wget -q -s http://localhost:2368 || exit 1
 VOLUME [ "${GHOST_CONTENT}", "${GHOST_INSTALL}/config.override.json" ]
 
 # Define default command
-CMD [ "/bin/sh", "-c", "/bin/sh ${GHOST_INSTALL}/run-ghost.sh" ]
+CMD [ "/sbin/tini", "--", "/bin/sh", "-c", "/bin/sh ${GHOST_INSTALL}/run-ghost.sh" ]


### PR DESCRIPTION
- Copy content.bck in the builder section
- Optimized ENV multi vars
- added apk update && apk upgrade in both sections
- add tini

---

### content.bkp
This way we saved a layer in the final image :)

### ENV

It looks like each time we are using ENV docker creates a layer. I guess it's better to optimise those. 

But I could not combine those 3 together without hitting an error

```
ENV HOME $GHOST_INSTALL
ENV PATH="${GHOST_INSTALL}/current/node_modules/knex-migrator/bin:${PATH}"
ENV NODE_ENV production
```

### apk update && apk upgrade 
As node:6 run on alpine 3.4, I think it's safer to upgrade the image

### tini

I tried to use the ENTRYPOINT with run-ghost.sh but I was getting permission issues. It would be better to run this way to we could run CMD [ "/sbin/tini", "--", "/bin/sh", "-c", "node", "current/index.js" ]. Ghost would run on PID 1. It's really about best practice.
