### PR TITLE
FEAT: Added entry point into the Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ before_script:
       fi
 script:
     - docker build -t "$image" .
-    - docker run -d --name blogtest -p 2368:2368 -e NODE_ENV=production "$image" init start
-    - until nc -z $(docker inspect --format='{{.NetworkSettings.IPAddress}}' blogtest) 2368; do
+    - docker run -d --name blogtest -p 2368:2368 -e WEB_URL=http://localhost:2368 -e NODE_ENV=production "$image" init start
+    - until $(curl --output /dev/null --silent --head --fail http://localhost:2368); do
           echo "waiting for ghostblog container...";
-          sleep 2;
+          sleep 10;
       done
     - echo "GhostTest available..."
     - official-images/test/run.sh "$image"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
       fi
 script:
     - docker build -t "$image" .
-    - docker run -d --name blogtest -p 2368:2368 -e NODE_ENV=production "$image"
+    - docker run -d --name blogtest -p 2368:2368 -e NODE_ENV=production "$image" init start
     - until nc -z $(docker inspect --format='{{.NetworkSettings.IPAddress}}' blogtest) 2368; do
           echo "waiting for ghostblog container...";
           sleep 2;

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
       fi
 script:
     - docker build -t "$image" .
-    - docker run -d --name blogtest -p 2368:2368 -e WEB_URL=http://localhost:2368 -e NODE_ENV=production "$image" init start
+    - docker run -d --name blogtest -p 2368:2368 -e WEB_URL=http://localhost:2368 -e NODE_ENV=production "$image"
     - until $(curl --output /dev/null --silent --head --fail http://localhost:2368); do
           echo "waiting for ghostblog container...";
           sleep 10;

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN \
     ghost config paths.contentPath "$GHOST_CONTENT"     ;
 
 COPY run-ghost.sh $GHOST_INSTALL
+RUN chmod +x "$GHOST_INSTALL/run-ghost.sh"
 
 # Here we could add custom themes within the Docker image
 
@@ -75,5 +76,8 @@ HEALTHCHECK CMD wget -q -s http://localhost:2368 || exit 1
 # Define mountable directories
 VOLUME [ "${GHOST_CONTENT}", "${GHOST_INSTALL}/config.override.json" ]
 
+# Define Entry Point to manage the Init and the upgrade
+ENTRYPOINT [ "./run-ghost.sh" ]
+
 # Define default command
-CMD [ "/sbin/tini", "--", "/bin/sh", "-c", "/bin/sh ${GHOST_INSTALL}/run-ghost.sh" ]
+CMD [ "node", "current/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ FROM node:6-alpine
 LABEL maintainer="Marco Mornati <marco@mornati.net>"
 
 RUN apk update && apk upgrade                           && \
-    apk add --no-cache tini                             && \
     rm -rf /var/cache/apk/*                             ;
 
 ENV GHOST_VERSION="1.17.1"                              \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ### ### ### ### ### ### ### ### ###
 # Builder layer
 
-FROM node:6-alpine as ghost-builder
+FROM node:8.9.1-alpine as ghost-builder
 
 RUN \
     apk update && apk upgrade                           && \
@@ -42,7 +42,7 @@ RUN cp -r "$GHOST_CONTENT" "$GHOST_INSTALL/content.bck" ;
 # Final image
 # No tzdata as it's not working on alpine3.4 (from node6)
 
-FROM node:6-alpine
+FROM node:8.9.1-alpine
 LABEL maintainer="Marco Mornati <marco@mornati.net>"
 
 RUN apk update && apk upgrade                           && \

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ This means you can override the configuration with a command like the following 
 docker run -d -p 2368:2368 -e WEB_URL=http://test.blog -v /opt/data:/var/lib/ghost/content -v /opt/myconfiguration.json:/var/lib/ghost/config.override.json mmornati/docker-ghostblog
 ```
 
+#### Execute Database Init
+The first time you start your ghost you may need to initialize the database to create empty tables. To do this just execute a command with the **init** parameter at the end.
+
+```bash
+docker run -v /opt/data:/var/lib/ghost/content -v /opt/myconfiguration.json:/var/lib/ghost/config.override.json mmornati/docker-ghostblog init
+```
+
+#### Execute Database Migration
+Like the init step, you can add the **migrate** parameter to the run command to execute the database migration.
+
+```bash
+docker run -v /opt/data:/var/lib/ghost/content -v /opt/myconfiguration.json:/var/lib/ghost/config.override.json mmornati/docker-ghostblog migrate
+```
+
 ### Upgrade from previous version (< 1.16.2)
 
 #### Data mount volume

--- a/README.md
+++ b/README.md
@@ -52,20 +52,6 @@ This means you can override the configuration with a command like the following 
 docker run -d -p 2368:2368 -e WEB_URL=http://test.blog -v /opt/data:/var/lib/ghost/content -v /opt/myconfiguration.json:/var/lib/ghost/config.override.json mmornati/docker-ghostblog
 ```
 
-#### Execute Database Init
-The first time you start your ghost you may need to initialize the database to create empty tables. To do this just execute a command with the **init** parameter at the end.
-
-```bash
-docker run -v /opt/data:/var/lib/ghost/content -v /opt/myconfiguration.json:/var/lib/ghost/config.override.json mmornati/docker-ghostblog init
-```
-
-#### Execute Database Migration
-Like the init step, you can add the **migrate** parameter to the run command to execute the database migration.
-
-```bash
-docker run -v /opt/data:/var/lib/ghost/content -v /opt/myconfiguration.json:/var/lib/ghost/config.override.json mmornati/docker-ghostblog migrate
-```
-
 ### Upgrade from previous version (< 1.16.2)
 
 #### Data mount volume

--- a/run-ghost.sh
+++ b/run-ghost.sh
@@ -38,17 +38,16 @@ if [ -z "$(ls -A "$GHOST_CONTENT")" ]; then
         cp -r $GHOST_INSTALL/content.bck/* $GHOST_CONTENT
 fi
 
-if [ ! -s "$(awk '/"filename": "(.*)"/ {print $2}' $CONFIG | sed -e s/\"//g)" ]; then
+if [[ "$*" == "init" ]]; then 
         echo "Empty database. Initializing..."
         knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
-else
-        echo "Database already exists. Executing migration (if needed)"
-        knex-migrator migrate --mgpath "$GHOST_INSTALL/current"
+        exit 0
 fi
 
-if [[ $start == 'true' ]]; then
-	# Start Ghost with Ghost CLI
-	# cd $GHOST_INSTALL && ghost run production
-        # Start Ghost with NODE
-        cd $GHOST_INSTALL && node current/index.js 
+if [[ "$*" == "migrate" ]]; then 
+        echo "Database already exists. Executing migration (if needed)"
+        knex-migrator migrate --mgpath "$GHOST_INSTALL/current"
+        exit 0
 fi
+
+exec $@

--- a/run-ghost.sh
+++ b/run-ghost.sh
@@ -1,13 +1,4 @@
 #!/bin/sh
-verbose='false'
-start='true'
-while getopts 'dv' flag; do
-  case "${flag}" in
-    d) start='false' ;;
-    v) verbose='true' ;;
-    *) start='true' ;;
-  esac
-done
 
 CONFIG="$GHOST_INSTALL/config.production.json"
 
@@ -29,10 +20,6 @@ echo "========================================================================"
 
 sed -i "s|http://localhost:2368/|$WEB_URL|g" config.production.json
 
-if [[ $verbose == 'true' ]]; then
-	cat $CONFIG
-fi
-
 if [ -z "$(ls -A "$GHOST_CONTENT")" ]; then
         echo "Missing content folder. Copying the default one..."
         cp -r $GHOST_INSTALL/content.bck/* $GHOST_CONTENT
@@ -40,8 +27,14 @@ fi
 
 if [[ "$*" == "init" ]]; then 
         echo "Empty database. Initializing..."
-        knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+        knex-migrator init --mgpath "$GHOST_INSTALL/current"
         exit 0
+fi
+
+if [[ "$*" == "init start" ]]; then 
+        echo "Empty database. Initializing..."
+        knex-migrator init --mgpath "$GHOST_INSTALL/current"
+        node current/index.js
 fi
 
 if [[ "$*" == "migrate" ]]; then 

--- a/run-ghost.sh
+++ b/run-ghost.sh
@@ -26,24 +26,14 @@ if [[ "$*" == "node current/index.js" ]]; then
                 echo "Missing content folder. Copying the default one..."
                 cp -r $GHOST_INSTALL/content.bck/* $GHOST_CONTENT
         fi
-fi
 
-if [[ "$*" == "init" ]]; then 
-        echo "Empty database. Initializing..."
-        knex-migrator init --mgpath "$GHOST_INSTALL/current"
-        exit 0
-fi
-
-if [[ "$*" == "init start" ]]; then 
-        echo "Empty database. Initializing..."
-        knex-migrator init --mgpath "$GHOST_INSTALL/current"
-        node current/index.js
-fi
-
-if [[ "$*" == "migrate" ]]; then 
-        echo "Database already exists. Executing migration (if needed)"
-        knex-migrator migrate --mgpath "$GHOST_INSTALL/current"
-        exit 0
+        if [ ! -s "$(awk '/"filename": "(.*)"/ {print $2}' $CONFIG | sed -e s/\"//g)" ]; then
+                echo "Empty database. Initializing..."
+                knex-migrator init --mgpath "$GHOST_INSTALL/current"
+        else
+                echo "Database already exists. Executing migration (if needed)"
+                knex-migrator migrate --mgpath "$GHOST_INSTALL/current"
+        fi
 fi
 
 exec "$@"

--- a/run-ghost.sh
+++ b/run-ghost.sh
@@ -1,28 +1,31 @@
 #!/bin/sh
+set -eo pipefail
 
-CONFIG="$GHOST_INSTALL/config.production.json"
+if [[ "$*" == "node current/index.js" ]]; then 
+        CONFIG="$GHOST_INSTALL/config.production.json"
 
-if [ -f $GHOST_INSTALL/config.override.json ]; then
-        echo "Ghost override provided. Override the internal configuration"
-        cp $GHOST_INSTALL/config.override.json $GHOST_INSTALL/config.production.json
-fi
+        if [ -f $GHOST_INSTALL/config.override.json ]; then
+                echo "Ghost override provided. Override the internal configuration"
+                cp $GHOST_INSTALL/config.override.json $GHOST_INSTALL/config.production.json
+        fi
 
-# Set Config
-if [ -z "$WEB_URL" ]; then
-	echo "WEB_URL is empty. Getting default: http://$(hostname -i):2368"
-	WEB_URL=http://$(hostname -i):2368
-fi
+        # Set Config
+        if [ -z "$WEB_URL" ]; then
+                echo "WEB_URL is empty. Getting default: http://$(hostname -i):2368"
+                WEB_URL=http://$(hostname -i):2368
+        fi
 
-echo "=> Change config based on ENV parameters:"
-echo "========================================================================"
-echo "      WEB_URL:        $WEB_URL"
-echo "========================================================================"
+        echo "=> Change config based on ENV parameters:"
+        echo "========================================================================"
+        echo "      WEB_URL:        $WEB_URL"
+        echo "========================================================================"
 
-sed -i "s|http://localhost:2368/|$WEB_URL|g" config.production.json
+        sed -i "s|http://localhost:2368/|$WEB_URL|g" config.production.json
 
-if [ -z "$(ls -A "$GHOST_CONTENT")" ]; then
-        echo "Missing content folder. Copying the default one..."
-        cp -r $GHOST_INSTALL/content.bck/* $GHOST_CONTENT
+        if [ -z "$(ls -A "$GHOST_CONTENT")" ]; then
+                echo "Missing content folder. Copying the default one..."
+                cp -r $GHOST_INSTALL/content.bck/* $GHOST_CONTENT
+        fi
 fi
 
 if [[ "$*" == "init" ]]; then 
@@ -43,4 +46,4 @@ if [[ "$*" == "migrate" ]]; then
         exit 0
 fi
 
-exec $@
+exec "$@"


### PR DESCRIPTION
With the new ENTRYPOINT operator into the Dockerfile we are now able to have ghost execute on the **PID 1**
![schermata 2017-11-14 alle 21 16 42](https://user-images.githubusercontent.com/139323/32802944-33875cfe-c982-11e7-8ae1-8acb7cc1356d.png)

**MIGRATE PROCEDURE**
To slim the docker start process (and allow it to start quickly) the migrate command is now executed only on demand.

```bash
docker run -v /opt/data:/var/lib/ghost/content -v /opt/myconfiguration.json:/var/lib/ghost/config.override.json mmornati/docker-ghostblog:latest migrate
```

**INIT PROCEDURE**
In the same way, during the first execution of the docker, we can initialize de database.

```bash
docker run -v /opt/data:/var/lib/ghost/content -v /opt/myconfiguration.json:/var/lib/ghost/config.override.json mmornati/docker-ghostblog:latest init
```

