### PR TITLE
Dockerfile optimisations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN set -ex                                                 && \
     apk add --no-cache tzdata                               && \
     rm -rf /var/cache/apk/*                                 ;
 
-ENV TZ Europe/Paris
+ENV TZ Etc/UTC
 
 # Install Ghost
 COPY --from=ghost-builder --chown=node $GHOST_INSTALL $GHOST_INSTALL

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,14 @@ RUN set -ex                                                 && \
     echo "---             S P A C E R             ---"      && \
     npm install --loglevel=error -g ghost-cli               && \
     echo "---             S P A C E R             ---"      && \
-    ghost install "$GHOST_VERSION" \
-        --db sqlite3 --no-prompt \
-        --no-stack --no-setup \
+    ghost install "$GHOST_VERSION"  \
+        --db sqlite3 --no-prompt    \
+        --no-stack --no-setup       \
         --dir "$GHOST_INSTALL"                              && \
     echo "---             S P A C E R             ---"      && \
-    ghost config --ip 0.0.0.0 \
-        --port 2368 --no-prompt --db sqlite3 \
-        --url http://localhost:2368 \
+    ghost config --ip 0.0.0.0                   \
+        --port 2368 --no-prompt --db sqlite3    \
+        --url http://localhost:2368             \
         --dbpath "$GHOST_CONTENT/data/ghost.db"             && \
     echo "---             S P A C E R             ---"      && \
     ghost config paths.contentPath "$GHOST_CONTENT"         ;

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN set -ex                                                 && \
     cp /usr/share/zoneinfo/America/New_York /etc/localtime  && \
     echo "America/New_York" > /etc/timezone                 && \
     apk del tzdata                                          && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/*                                 ;
 
 # Install Ghost
 COPY --from=ghost-builder --chown=node $GHOST_INSTALL $GHOST_INSTALL

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,14 +49,13 @@ ENV GHOST_VERSION="1.17.2"                                  \
     GHOST_CONTENT="/var/lib/ghost/content"                  \
     GHOST_USER="node"                                       \
     HOME="$GHOST_INSTALL"                                   \
+    TZ="Etc/UTC"                                            \
     NODE_ENV="production"
 
 RUN set -ex                                                 && \
     apk update && apk upgrade                               && \
     apk add --no-cache tzdata                               && \
     rm -rf /var/cache/apk/*                                 ;
-
-ENV TZ Etc/UTC
 
 # Install Ghost
 COPY --from=ghost-builder --chown=node $GHOST_INSTALL $GHOST_INSTALL

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,6 @@ WORKDIR $GHOST_INSTALL
 # We use SQLite as our DB
 RUN set -ex                                                 && \
     apk update && apk upgrade                               && \
-    apk add --no-cache tzdata                               && \
-    cp /usr/share/zoneinfo/America/New_York /etc/localtime  && \
-    echo "America/New_York" > /etc/timezone                 && \
-    apk del tzdata                                          && \
-    rm -rf /var/cache/apk/*                                 && \
     echo "---             S P A C E R             ---"      && \
     npm install --loglevel=error -g ghost-cli               && \
     echo "---             S P A C E R             ---"      && \
@@ -59,10 +54,9 @@ ENV GHOST_VERSION="1.17.2"                                  \
 RUN set -ex                                                 && \
     apk update && apk upgrade                               && \
     apk add --no-cache tzdata                               && \
-    cp /usr/share/zoneinfo/America/New_York /etc/localtime  && \
-    echo "America/New_York" > /etc/timezone                 && \
-    apk del tzdata                                          && \
     rm -rf /var/cache/apk/*                                 ;
+
+ENV TZ Europe/Paris
 
 # Install Ghost
 COPY --from=ghost-builder --chown=node $GHOST_INSTALL $GHOST_INSTALL
@@ -81,7 +75,7 @@ EXPOSE 2368
 HEALTHCHECK CMD wget -q -s http://localhost:2368 || exit 1
 
 # Define mountable directories
-VOLUME [ "${GHOST_CONTENT}", "${GHOST_INSTALL}/config.override.json" ]
+VOLUME [ "${GHOST_CONTENT}", "${GHOST_INSTALL}/config.override.json", "/etc/timezone" ]
 
 # Define Entry Point to manage the Init and the upgrade
 ENTRYPOINT [ "./run-ghost.sh" ]

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 ### Base Docker Image
 
-* [node:6-alpine](https://registry.hub.docker.com/_/node/)
-
+* [node:8.9.1-alpine](https://registry.hub.docker.com/_/node/)
 
 ### Installation
 
@@ -31,9 +30,9 @@ docker pull mmornati/docker-ghostblog
 
     docker run -d -p 80:2368 -e [ENVIRONMENT_VARIABLES] -v <override-dir>:/var/lib/ghost/content mmornati/docker-ghostblog
 
-Environment variables are used to personalise your Ghost Blog configuration. Could be:
+Environment variables are used to personalize your Ghost Blog configuration. Could be:
 
-* WEB_URL: the url used to expose your blog (default: blog.mornati.net)
+* WEB_URL: the URL used to expose your blog (default: blog.mornati.net)
 
 A complete running command line could be:
 
@@ -41,9 +40,9 @@ A complete running command line could be:
 docker run -d -p 2368:2368 -e WEB_URL=http://test.blog -v /opt/data:/var/lib/ghost/content mmornati/docker-ghostblog
 ```
 
-#### Custimize providing a custom configuration
+#### Customize providing a custom configuration
 
-If you want to customize your Ghost using, for example, a mail server, adding plugins and configure them, ... you can provide a complete configuration file which is be used instead of the internal one.
+If you want to customize your Ghost using, for example, a mail server, adding plugins and configure them, ... you can provide a complete configuration file which is being used instead of the internal one.
 To do this a new volume is available: **/var/lib/ghost/config.override.json**
 
 This means you can override the configuration with a command like the following one:
@@ -55,6 +54,7 @@ docker run -d -p 2368:2368 -e WEB_URL=http://test.blog -v /opt/data:/var/lib/gho
 ### Upgrade from previous version (< 1.16.2)
 
 #### Data mount volume
+
 If you were using this container with previous version, since the 1.16.2 we aligned the folders used inside the Docker to the ones used by the [Ghost official image](https://hub.docker.com/_/ghost/), you maybe need to change your data mount point.
 
 Before you had:
@@ -72,6 +72,7 @@ Starting from this version your mount point should change to:
 ```
 
 #### Mount Volume access rights
+
 To be complete the official image aligned, even the user used to run the ghost service changed from **ghost** to **node**.
 This means if you had a previous installation of this docker, you should change the ownership of files in your folder or docker volume:
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ This means you can override the configuration with a command like the following 
 docker run -d -p 2368:2368 -e WEB_URL=http://test.blog -v /opt/data:/var/lib/ghost/content -v /opt/myconfiguration.json:/var/lib/ghost/config.override.json mmornati/docker-ghostblog
 ```
 
+#### Configure TimeZone
+If you want to configure TimeZone for the logging you can use the TZ environment variable with the timezone you need. For example:
+
+```bash
+docker run -p 2368:2368 -e TZ=America/Los_Angeles -e WEB_URL=http://localhost:2368 mmornati/docker-ghostblog date
+Wed Nov 15 12:57:23 PST 2017
+```
+
 ### Upgrade from previous version (< 1.16.2)
 
 #### Data mount volume


### PR DESCRIPTION
### Overall, it's cleaner

- using `set -ex` when doing `RUN`
- Re-order `ENV` before `RUN`
- better grouping of `ENV`
- better indentation
- remove unnecessary comments
- Minimize the number of RUN
- adding this to make the dockerfile easier to read --> `echo "---             S P A C E R             ---"      && \`

### Minor readme update

