### PR TITLE
attempt to hot-patch permission errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR $GHOST_INSTALL
 #Install required packages
 RUN set -eux                            && \
     apk update && apk add python make   && \
-    chown node:node "$GHOST_INSTALL"    && \
+    chown -R node:node "$GHOST_INSTALL" && \
     chmod g+rw "$GHOST_INSTALL";
 
 USER $GHOST_USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ WORKDIR $GHOST_INSTALL
 #Install required packages
 RUN set -eux                            && \
     apk update && apk add python make   && \
-    chown node:node "$GHOST_INSTALL"     
+    chown node:node "$GHOST_INSTALL"    && \
+    chmod g+rw "$GHOST_INSTALL";
 
 USER $GHOST_USER
 


### PR DESCRIPTION
Supposedly fixes #37 


I took a look at one of the [containers](https://github.com/ClarityMoe/cloud9-on-openshift/blob/master/f26/run_container.sh#L54) I maintain, and I noticed that we lacked ``chmod`` to allow ``node`` to write, so even if we chown it, it won't have write access.